### PR TITLE
feat: enhance mobile responsiveness & remove MainComposer module redu…

### DIFF
--- a/.changeset/fresh-apricots-drive.md
+++ b/.changeset/fresh-apricots-drive.md
@@ -1,0 +1,5 @@
+---
+'@octopost/core': patch
+---
+
+In this Changeset, in general, were add features regarding a Adjusting Main Content for Mobile Version.

--- a/.changeset/tender-boxes-knock.md
+++ b/.changeset/tender-boxes-knock.md
@@ -1,0 +1,5 @@
+---
+'@octopost/core': patch
+---
+
+In general, were add features regarding a Adjusting Main Content for Mobile Version.

--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -1,56 +1,8 @@
 @use '../../styles/global.scss' as *;
-@use '../../styles/breakpoints.scss';
-
-.container {
-  @include breakpoints.from600 {
-    display: flex;
-    flex-direction: column;
-
-    align-items: stretch;
-
-    font-family: $mainFont;
-
-    font-size: 1.6rem;
-
-    border: 1px solid #cbc4cf;
-
-    background-color: $primaryWhite;
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-    border-radius: 17px 17px 0 0;
-  }
-}
+@use '~styles/breakpoints.scss';
 
 .header {
   display: none;
-  @include breakpoints.from600 {
-    width: 100%;
-
-    display: flex;
-    flex-flow: row nowrap;
-
-    align-items: center;
-
-    justify-content: space-between;
-
-    color: $primaryWhite;
-    font-size: 1.6rem;
-    line-height: 1;
-
-    padding: 1.2rem;
-
-    position: relative;
-
-    background-color: $secondaryPurple;
-    border-radius: 17px 17px 0 0;
-
-    &::before {
-      font-size: 1.8rem;
-
-      margin-right: 1rem;
-
-      content: '⬤';
-    }
-  }
 }
 
 .headerTitle {

--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -1,49 +1,55 @@
 @use '../../styles/global.scss' as *;
+@use '../../styles/breakpoints.scss';
 
 .container {
-  display: flex;
-  flex-direction: column;
+  @include breakpoints.from600 {
+    display: flex;
+    flex-direction: column;
 
-  align-items: stretch;
+    align-items: stretch;
 
-  font-family: $mainFont;
+    font-family: $mainFont;
 
-  font-size: 1.6rem;
+    font-size: 1.6rem;
 
-  border: 1px solid #cbc4cf;
+    border: 1px solid #cbc4cf;
 
-  background-color: $primaryWhite;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  border-radius: 17px 17px 0 0;
+    background-color: $primaryWhite;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+    border-radius: 17px 17px 0 0;
+  }
 }
 
 .header {
-  width: 100%;
+  display: none;
+  @include breakpoints.from600 {
+    width: 100%;
 
-  display: flex;
-  flex-flow: row nowrap;
+    display: flex;
+    flex-flow: row nowrap;
 
-  align-items: center;
+    align-items: center;
 
-  justify-content: space-between;
+    justify-content: space-between;
 
-  color: $primaryWhite;
-  font-size: 1.6rem;
-  line-height: 1;
+    color: $primaryWhite;
+    font-size: 1.6rem;
+    line-height: 1;
 
-  padding: 1.2rem;
+    padding: 1.2rem;
 
-  position: relative;
+    position: relative;
 
-  background-color: $secondaryPurple;
-  border-radius: 17px 17px 0 0;
+    background-color: $secondaryPurple;
+    border-radius: 17px 17px 0 0;
 
-  &::before {
-    font-size: 1.8rem;
+    &::before {
+      font-size: 1.8rem;
 
-    margin-right: 1rem;
+      margin-right: 1rem;
 
-    content: '⬤';
+      content: '⬤';
+    }
   }
 }
 

--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -1,8 +1,56 @@
 @use '../../styles/global.scss' as *;
-@use '~styles/breakpoints.scss';
+@use '../../styles/breakpoints.scss';
+
+.container {
+  @include breakpoints.from600 {
+    display: flex;
+    flex-direction: column;
+
+    align-items: stretch;
+
+    font-family: $mainFont;
+
+    font-size: 1.6rem;
+
+    border: 1px solid #cbc4cf;
+
+    background-color: $primaryWhite;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+    border-radius: 17px 17px 0 0;
+  }
+}
 
 .header {
   display: none;
+  @include breakpoints.from600 {
+    width: 100%;
+
+    display: flex;
+    flex-flow: row nowrap;
+
+    align-items: center;
+
+    justify-content: space-between;
+
+    color: $primaryWhite;
+    font-size: 1.6rem;
+    line-height: 1;
+
+    padding: 1.2rem;
+
+    position: relative;
+
+    background-color: $secondaryPurple;
+    border-radius: 17px 17px 0 0;
+
+    &::before {
+      font-size: 1.8rem;
+
+      margin-right: 1rem;
+
+      content: '⬤';
+    }
+  }
 }
 
 .headerTitle {

--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -1,56 +1,8 @@
 @use '../../styles/global.scss' as *;
-@use '../../styles/breakpoints.scss';
-
-.container {
-  @include breakpoints.from600 {
-    display: flex;
-    flex-direction: column;
-
-    align-items: stretch;
-
-    font-family: $mainFont;
-
-    font-size: 1.6rem;
-
-    border: 1px solid #cbc4cf;
-
-    background-color: $primaryWhite;
-    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-    border-radius: 17px 17px 0 0;
-  }
-}
+@use '~styles/breakpoints.scss';
 
 .header {
   display: none;
-  @include breakpoints.from600 {
-    width: 100%;
-
-    display: flex;
-    flex-flow: row nowrap;
-
-    align-items: center;
-
-    justify-content: space-between;
-
-    color: $primaryWhite;
-    font-size: 1.6rem;
-    line-height: 1;
-
-    padding: 1.2rem;
-
-    position: relative;
-
-    background-color: $secondaryPurple;
-    border-radius: 17px 17px 0 0;
-
-    &::before {
-      font-size: 1.8rem;
-
-      margin-right: 1rem;
-
-      content: '⬤';
-    }
-  }
 }
 
 .headerTitle {
@@ -72,4 +24,51 @@
   margin-right: 2rem;
 
   cursor: pointer;
+}
+
+@include breakpoints.from600 {
+  .container {
+    display: flex;
+    flex-direction: column;
+
+    align-items: stretch;
+
+    font-family: $mainFont;
+    font-size: 1.6rem;
+
+    border: 1px solid #cbc4cf;
+
+    background-color: $primaryWhite;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+    border-radius: 17px 17px 0 0;
+  }
+
+  .header {
+    width: 100%;
+
+    display: flex;
+    flex-flow: row nowrap;
+
+    align-items: center;
+    justify-content: space-between;
+
+    color: $primaryWhite;
+    font-size: 1.6rem;
+    line-height: 1;
+
+    padding: 1.2rem;
+
+    position: relative;
+
+    background-color: $secondaryPurple;
+    border-radius: 17px 17px 0 0;
+
+    &::before {
+      font-size: 1.8rem;
+
+      margin-right: 1rem;
+
+      content: '⬤';
+    }
+  }
 }

--- a/src/components/MainComposer/MainComposer.module.scss
+++ b/src/components/MainComposer/MainComposer.module.scss
@@ -1,59 +1,13 @@
 @use '~styles/global.scss';
-
-.header {
-  font-size: 2rem;
-
-  padding: 1rem 2rem;
-
-  background-color: global.$secondaryPurple;
-  border-radius: 2rem 2rem 0 0;
-
-  .mainContent {
-    .mainText {
-      color: global.$primaryWhite;
-      font-size: 2.2rem;
-      font-weight: 400;
-      font-style: normal;
-      line-height: 2.8rem;
-
-      &::before {
-        width: 1.5rem;
-        height: 1.5rem;
-
-        display: inline-block;
-
-        float: left;
-
-        margin-top: 0.7rem;
-        margin-right: 1rem;
-
-        background-color: global.$primaryWhite;
-        border-radius: 50%;
-
-        content: '';
-      }
-
-      &::after {
-        width: 2rem;
-        height: 0.5rem;
-
-        display: inline-block;
-
-        float: right;
-
-        margin-top: 1.4rem;
-        margin-left: 1rem;
-
-        background-color: global.$primaryWhite;
-
-        content: '';
-      }
-    }
-  }
-}
+@use '../../styles/breakpoints.scss';
 
 .content {
   padding: 2.4rem 1.6rem;
+}
+
+.textInput {
+  display: grid;
+  grid-template-columns: 5fr 1fr;
 }
 
 .textInput textarea {
@@ -70,15 +24,41 @@
 }
 
 .contentBotTop {
+  display: flex;
+
+  justify-content: space-between;
+
   font-size: 1.6rem;
 
+  padding: 1rem 0;
+
   border-bottom: 0.1rem solid global.$primaryGray;
+
+  .socialMedias {
+    display: flex;
+
+    align-items: center;
+  }
 }
 
 .contentBotBot {
   font-size: 1.6rem;
 
   margin-bottom: 2.4rem;
+
+  .iconPulsSave {
+    display: flex;
+
+    align-items: center;
+    justify-content: space-between;
+
+    margin-top: 3rem;
+
+    .icons {
+      display: flex;
+      gap: 1.5rem;
+    }
+  }
 }
 
 .mainComposerInputMedia {

--- a/src/components/MainComposer/MainComposer.module.scss
+++ b/src/components/MainComposer/MainComposer.module.scss
@@ -1,5 +1,5 @@
 @use '~styles/global.scss';
-@use '../../styles/breakpoints.scss';
+@use '~styles/breakpoints.scss';
 
 .content {
   padding: 2.4rem 1.6rem;

--- a/src/components/MainComposer/MainComposer.tsx
+++ b/src/components/MainComposer/MainComposer.tsx
@@ -19,25 +19,12 @@ function MainComposer() {
           <ComposerEditor />
         </div>
         <div className={scss.contentBot}>
-          <div className={scss.contentBotTop}>
-            <div>left</div>
-            <div className={scss.socialMedias}>
-              <p>Right</p>
-            </div>
-          </div>
+          <div className={scss.contentBotTop}></div>
           <div className={scss.contentBotBot}>
             <div className={scss.mainComposerInputMedia}>
               <MediaInputs />
             </div>
-            {/* <h2>content-bot-bot</h2> */}
-            <div className={scss.iconPulsSave}>
-              <div className={scss.icons}>
-                <p>left</p>
-              </div>
-              <div>
-                <p>right</p>
-              </div>
-            </div>
+            <div className={scss.iconPulsSave}></div>
 
             <p>{t('We have a lot of work')}</p>
           </div>

--- a/src/components/MainComposer/MainComposer.tsx
+++ b/src/components/MainComposer/MainComposer.tsx
@@ -20,13 +20,25 @@ function MainComposer() {
         </div>
         <div className={scss.contentBot}>
           <div className={scss.contentBotTop}>
-            <h2>content-bot-top</h2>
+            <div>left</div>
+            <div className={scss.socialMedias}>
+              <p>Right</p>
+            </div>
           </div>
           <div className={scss.contentBotBot}>
             <div className={scss.mainComposerInputMedia}>
               <MediaInputs />
             </div>
-            <h2>content-bot-bot</h2>
+            {/* <h2>content-bot-bot</h2> */}
+            <div className={scss.iconPulsSave}>
+              <div className={scss.icons}>
+                <p>left</p>
+              </div>
+              <div>
+                <p>right</p>
+              </div>
+            </div>
+
             <p>{t('We have a lot of work')}</p>
           </div>
         </div>

--- a/src/pages/home/components/Header/Header.module.scss
+++ b/src/pages/home/components/Header/Header.module.scss
@@ -1,10 +1,18 @@
+@use '../../../../styles/breakpoints.scss';
+
 .header {
-  width: 100%;
+  display: none;
 
-  margin-bottom: 6.8rem;
+  @include breakpoints.from600 {
+    width: 100%;
 
-  padding: 1.6rem 3.2rem;
+    display: block;
 
-  background: rgba(255, 255, 255, 0.01);
-  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
+    margin-bottom: 6.8rem;
+
+    padding: 1.6rem 3.2rem;
+
+    background: rgba(255, 255, 255, 0.01);
+    box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
+  }
 }

--- a/src/pages/home/components/Header/Header.module.scss
+++ b/src/pages/home/components/Header/Header.module.scss
@@ -1,14 +1,18 @@
 @use '~styles/breakpoints.scss';
 
 .header {
-  width: 100%;
+  display: none;
 
-  display: block;
+  @include breakpoints.from600 {
+    width: 100%;
 
-  margin-bottom: 6.8rem;
+    display: block;
 
-  padding: 1.6rem 3.2rem;
+    margin-bottom: 6.8rem;
 
-  background: rgba(255, 255, 255, 0.01);
-  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
+    padding: 1.6rem 3.2rem;
+
+    background: rgba(255, 255, 255, 0.01);
+    box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
+  }
 }

--- a/src/pages/home/components/Header/Header.module.scss
+++ b/src/pages/home/components/Header/Header.module.scss
@@ -1,18 +1,14 @@
 @use '~styles/breakpoints.scss';
 
 .header {
-  display: none;
+  width: 100%;
 
-  @include breakpoints.from600 {
-    width: 100%;
+  display: block;
 
-    display: block;
+  margin-bottom: 6.8rem;
 
-    margin-bottom: 6.8rem;
+  padding: 1.6rem 3.2rem;
 
-    padding: 1.6rem 3.2rem;
-
-    background: rgba(255, 255, 255, 0.01);
-    box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
-  }
+  background: rgba(255, 255, 255, 0.01);
+  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
 }

--- a/src/pages/home/components/Header/Header.module.scss
+++ b/src/pages/home/components/Header/Header.module.scss
@@ -1,18 +1,14 @@
-@use '../../../../styles/breakpoints.scss';
+@use '~styles/breakpoints.scss';
 
 .header {
-  display: none;
+  width: 100%;
 
-  @include breakpoints.from600 {
-    width: 100%;
+  display: block;
 
-    display: block;
+  margin-bottom: 6.8rem;
 
-    margin-bottom: 6.8rem;
+  padding: 1.6rem 3.2rem;
 
-    padding: 1.6rem 3.2rem;
-
-    background: rgba(255, 255, 255, 0.01);
-    box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
-  }
+  background: rgba(255, 255, 255, 0.01);
+  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);
 }

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -88,9 +88,9 @@
       'switches tabs';
     grid-template-rows: 1fr 2fr;
     grid-template-columns: 28.4rem 1fr;
-    gap: 10px;
+    gap: 1rem;
 
-    padding: 0 2%;
+    padding: 0 2rem;
 
     .gridSwitches {
       display: block;

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -62,26 +62,6 @@
   .gridInput > :not(:first-child) {
     display: none;
   }
-
-  @include breakpoints.from600 {
-    width: 100%;
-
-    display: grid;
-    grid-template-areas:
-      'switches input'
-      'switches tabs';
-    grid-template-rows: 1fr 2fr;
-    grid-template-columns: 28.4rem 1fr;
-    gap: 10px;
-
-    .gridSwitches {
-      display: block;
-    }
-
-    .gridInput > :not(:first-child) {
-      display: block;
-    }
-  }
 }
 
 .gridSwitches {
@@ -96,7 +76,32 @@
 
 .gridSavBar {
   display: none;
-  @include breakpoints.from600 {
+}
+
+@include breakpoints.from600 {
+  .gridContainer {
+    width: 100%;
+
+    display: grid;
+    grid-template-areas:
+      'switches input'
+      'switches tabs';
+    grid-template-rows: 1fr 2fr;
+    grid-template-columns: 28.4rem 1fr;
+    gap: 10px;
+
+    padding: 0 2%;
+
+    .gridSwitches {
+      display: block;
+    }
+
+    .gridInput > :not(:first-child) {
+      display: block;
+    }
+  }
+
+  .gridSavBar {
     display: block;
   }
 }

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -1,5 +1,5 @@
 @use '~styles/global.scss';
-@use '../../styles/breakpoints.scss';
+@use '~styles/breakpoints.scss';
 
 .home {
   display: grid;

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -1,4 +1,5 @@
 @use '~styles/global.scss';
+@use '../../styles/breakpoints.scss';
 
 .home {
   display: grid;
@@ -29,8 +30,7 @@
 }
 
 .mainContainer {
-  width: 90%;
-
+  width: 100%;
   max-width: 120rem;
 
   align-items: center;
@@ -40,15 +40,48 @@
 }
 
 .gridContainer {
-  width: 100%;
-
-  display: grid;
   grid-template-areas:
-    'switches input'
-    'switches tabs';
-  grid-template-rows: 1fr 2fr;
-  grid-template-columns: 28.4rem 1fr;
-  gap: 10px;
+    'switches'
+    'input'
+    'tabs';
+  grid-template-rows: auto;
+  grid-template-columns: 1fr;
+
+  text-align: center;
+
+  margin: 0 auto;
+
+  .gridSwitches {
+    display: none;
+
+    &.gridSwitchesVisible {
+      display: block;
+    }
+  }
+
+  .gridInput > :not(:first-child) {
+    display: none;
+  }
+
+  @include breakpoints.from600 {
+    width: 100%;
+
+    display: grid;
+    grid-template-areas:
+      'switches input'
+      'switches tabs';
+    grid-template-rows: 1fr 2fr;
+    grid-template-columns: 28.4rem 1fr;
+    gap: 10px;
+
+    .gridSwitches {
+      display: block;
+    }
+
+    .gridInput > :not(:first-child) {
+      display: block;
+    }
+  }
 }
 
 .gridSwitches {
@@ -59,4 +92,11 @@
   display: flex;
   flex-direction: column;
   grid-area: input;
+}
+
+.gridSavBar {
+  display: none;
+  @include breakpoints.from600 {
+    display: block;
+  }
 }

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -62,26 +62,6 @@
   .gridInput > :not(:first-child) {
     display: none;
   }
-
-  @include breakpoints.from600 {
-    width: 100%;
-
-    display: grid;
-    grid-template-areas:
-      'switches input'
-      'switches tabs';
-    grid-template-rows: 1fr 2fr;
-    grid-template-columns: 28.4rem 1fr;
-    gap: 10px;
-
-    .gridSwitches {
-      display: block;
-    }
-
-    .gridInput > :not(:first-child) {
-      display: block;
-    }
-  }
 }
 
 .gridSwitches {

--- a/src/pages/home/home.module.scss
+++ b/src/pages/home/home.module.scss
@@ -62,6 +62,26 @@
   .gridInput > :not(:first-child) {
     display: none;
   }
+
+  @include breakpoints.from600 {
+    width: 100%;
+
+    display: grid;
+    grid-template-areas:
+      'switches input'
+      'switches tabs';
+    grid-template-rows: 1fr 2fr;
+    grid-template-columns: 28.4rem 1fr;
+    gap: 10px;
+
+    .gridSwitches {
+      display: block;
+    }
+
+    .gridInput > :not(:first-child) {
+      display: block;
+    }
+  }
 }
 
 .gridSwitches {

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,7 +1,6 @@
 import FeedbackError from '~components/FeedbackError/FeedbackError';
 import FirstComment from '~components/FirstComment/FirstComment';
 import MainComposer from '~components/MainComposer/MainComposer';
-import MediaInputs from '~components/MediaInputs/MediaInput';
 import SavBar from '~components/SavBar/SavBar';
 
 import Header from './components/Header/Header';
@@ -20,12 +19,13 @@ const Home = () => {
           </div>
           <div className={scss.gridInput}>
             <MainComposer />
-            <MediaInputs />
             <FirstComment />
             <FeedbackError />
           </div>
         </div>
-        <SavBar />
+        <div className={scss.gridSavBar}>
+          <SavBar />
+        </div>
       </div>
     </>
   );

--- a/src/styles/breakpoints.scss
+++ b/src/styles/breakpoints.scss
@@ -1,11 +1,11 @@
-$phoneScreen: 37.5rem; // 600px **
-$tabletScreen: 56.5rem; // 905px **
+$phoneScreen: 37.5rem; // 600px
+$tabletScreen: 56.5rem; // 905px
 $desktopScreen: 77.5rem; // 1240px
-$largeDesktopScreen: 90rem; // 1440px **
+$largeDesktopScreen: 90rem; // 1440px
 
 $breakpointPhone: 20rem; // 320px
 $breakpointTablet: 30rem; // 480px
-$breakpointDesktop: 120rem; // 1920px **
+$breakpointDesktop: 120rem; // 1920px
 
 @mixin from320 {
   @media screen and (min-width: $breakpointPhone) {

--- a/src/styles/breakpoints.scss
+++ b/src/styles/breakpoints.scss
@@ -1,11 +1,11 @@
-$phoneScreen: 37.5rem; // 600px
-$tabletScreen: 56.5rem; // 905px
+$phoneScreen: 37.5rem; // 600px **
+$tabletScreen: 56.5rem; // 905px **
 $desktopScreen: 77.5rem; // 1240px
-$largeDesktopScreen: 90rem; // 1440px
+$largeDesktopScreen: 90rem; // 1440px **
 
 $breakpointPhone: 20rem; // 320px
 $breakpointTablet: 30rem; // 480px
-$breakpointDesktop: 120rem; // 1920px
+$breakpointDesktop: 120rem; // 1920px **
 
 @mixin from320 {
   @media screen and (min-width: $breakpointPhone) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '~styles/global.scss': path.join(__dirname, 'src/styles/global.scss'),
+      '~styles': path.join(__dirname, 'src/styles'),
     },
   },
   build: {


### PR DESCRIPTION
<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Foram realizados ajustes na versão mobile do componente Main Content para melhorar a experiência de uso em dispositivos móveis, o que envolveu a remoção de certas funcionalidades, como, por exemplo, no MainComposer.

</details>


<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>


https://github.com/devhatt/octopost/assets/30197026/77588b3d-2774-4c7e-86eb-6ba8300639e3


![image](https://github.com/devhatt/octopost/assets/30197026/0672d8a6-d4e4-45ec-b7c9-99f521a542e0)




</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>


Foram feitas modificações nas características do MainComposer, uma vez que algumas delas estavam sem utilização, já que o SCSS desempenhava a função do AccordionTab. No contexto do MainComposer, foram adicionadas divisões visando a organização disponibilizada no layout, seguindo a disposição mostrada na captura de tela do painel acima, utilizando os termos "left" e "right" para indicar as divs onde entraram futuros componentes.

</details>
