### PR TITLE
AccordionTab TextArea Adjustment

### DIFF
--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -68,7 +68,7 @@
 
       margin-right: 1rem;
 
-      content: '⬤';
+      content: '●';
     }
   }
 }

--- a/src/components/CharacterLimitMainText/components/CharacterLimit.tsx
+++ b/src/components/CharacterLimitMainText/components/CharacterLimit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -8,6 +8,7 @@ import { IModuleProps } from '../CharacterLimitMainText.types';
 
 function CharacterLimit(props: IModuleProps) {
   const [counterZero, setCounterZero] = useState(false);
+  const maxLengthCharacters = props.maxLength;
   const remainingCharacters = props.maxLength - props.value.length;
 
   useEffect(() => {
@@ -26,7 +27,9 @@ function CharacterLimit(props: IModuleProps) {
     <div className={svgColor}>
       {props.svg}
       <div className={characterLimitClass}>
-        <span>{remainingCharacters}</span>
+        <span>
+          {maxLengthCharacters}/{remainingCharacters}
+        </span>
       </div>
     </div>
   );

--- a/src/components/MainComposer/MainComposer.module.scss
+++ b/src/components/MainComposer/MainComposer.module.scss
@@ -6,21 +6,20 @@
 }
 
 .textInput {
-  display: grid;
-  grid-template-columns: 5fr 1fr;
-}
+  padding: 0.313rem;
 
-.textInput textarea {
-  width: 100%;
-  height: 15rem;
+  textarea {
+    width: 100%;
+    height: 12.5rem;
 
-  font-size: 1.6rem;
+    font-size: 1.5rem;
 
-  margin-bottom: 2.4rem;
-  border: 0;
-  box-sizing: border-box;
+    border: 0;
 
-  resize: none;
+    outline: none;
+
+    resize: none;
+  }
 }
 
 .contentBotTop {
@@ -63,7 +62,8 @@
 
 .mainComposerInputMedia {
   display: flex;
-  gap: 3.2rem;
+
+  justify-content: space-between;
 
   margin-top: 2.4rem;
 }


### PR DESCRIPTION
Closes

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

I adjusted the AccordionTab TextArea to fill the entire space of the component.
I also added the maximum allowed value to the remaining character count indicator, analogous to the prototype, and change the size of AccordionTab circle.

Issue - #358

</details>

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
  N/A

- **Cause**
  N/A

- **Solution**
N/A
</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>
N/A
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![302079979-1fe391d6-7026-4afd-86a1-ee0c034bb35c.png](https://github.com/devhatt/octopost/assets/67990430/6c535db3-16ed-48c1-9742-0870801ff5f0)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [ ] Issue linked
- [ ] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
</details>
