### PR TITLE
chore: refactor searchclue render logic

### DIFF
--- a/src/pages/home/components/Sidebar/Sidebar.tsx
+++ b/src/pages/home/components/Sidebar/Sidebar.tsx
@@ -58,7 +58,7 @@ function Sidebar(): ReactNode {
             ref={inputSearchRef}
           />
 
-          {value && renderSearchClue()}
+        {value ? renderSearchClue() : null}
 
           <div className={scss.items}>
             Item 1 <br /> Item2 <br /> Item 1 <br /> Item2 <br />


### PR DESCRIPTION
Closes

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Neste PR simplesmente ajustamos a logica de renderizacao do searchClue onde ele estava sendo renderizado enquanto nao havia texto e escondido quando havia texto.

![image](https://github.com/devhatt/octopost/assets/17785028/51a298fd-4bbc-498c-b098-60d1694e2f64)

Agora funcionando como deveria.

![image](https://github.com/devhatt/octopost/assets/17785028/8839edc9-6f59-4a21-a23a-43da8e0d308d)

apenas alteramos a ordem das logicas.
![image](https://github.com/devhatt/octopost/assets/17785028/36b22e9b-7446-4548-bdad-346fb5f10990)
