### PR TITLE
Reajuste dos stories do Button

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -4,42 +4,36 @@ import { Icon } from '~components/Icon/Icon';
 
 import Button from './Button';
 
-import { ICircleButtonProps } from './Button.types';
+import { ICircleButtonProps, ITextButtonProps } from './Button.types';
 
-export const ButtonStories: Story = () => (
-  <div>
-    <Button>Primary Text</Button>
-    <Button variant="container">Primary Container</Button>
-    <Button variant="outlined">Primary Outlined</Button>
-    <br />
-    <Button color="secondary">Secondary Text</Button>
-    <Button color="secondary" variant="container">
-      Secondary Container
-    </Button>
-    <Button color="secondary" variant="outlined">
-      Secondary Outlined
-    </Button>
-    <br />
-    <Button circle icon={<Icon icon="alert" />} />
-    <Button circle icon={<Icon icon="check" />} variant="container" />
-    <Button circle icon={<Icon icon="close" />} variant="outlined" />
-    <br />
-    <Button circle color="secondary" icon={<Icon icon="star" />} />
-    <Button
-      circle
-      color="secondary"
-      icon={<Icon icon="right-arrow" />}
-      variant="container"
-    />
-    <Button
-      circle
-      color="secondary"
-      icon={<Icon icon="star" />}
-      variant="outlined"
-    />
-  </div>
+export default {
+  argTypes: {
+    color: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary'],
+    },
+    disabled: {
+      control: { type: 'check' },
+      options: [''],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['container', 'outlined', 'text'],
+    },
+  },
+};
+
+export const ButtonText: Story<ITextButtonProps> = (props) => (
+  <Button
+    color={props.color}
+    disabled={props.disabled}
+    type={props.type}
+    variant={props.variant}
+  >
+    Button
+  </Button>
 );
-ButtonStories.args = {
+ButtonText.args = {
   color: 'primary',
   variant: 'container',
 };


### PR DESCRIPTION
Closes #442 

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
  Reajustando os stories do componente de button.

- **Cause**
  No PR #412 o arquivo button.stories.tsx foi alterado para a sua versão antiga que já tinha sido arrumado no PR #436. Agora é necessário ajustar para a sua atualização correta.

- **Solution**
N/A
</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>
N/A
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

Antes:
![image](https://github.com/devhatt/octopost/assets/90076846/22d636f8-128e-479d-9aef-4f2911108595)

Depois:
![image](https://github.com/devhatt/octopost/assets/90076846/fccdb72e-1071-46eb-b480-5b3d82e9badb)
![image](https://github.com/devhatt/octopost/assets/90076846/448d4664-1512-40ce-9827-22b0de8be12c)


</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
