### PR TITLE
Issue 428 - Ajuste do Modal segundo o design do figma

### DIFF
--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -88,11 +88,4 @@
 .headerButtons {
   display: flex;
   gap: 1.6rem;
-
-  //button {
-  //  width: 2.4rem;
-  //  height: 2.4rem;
-  //
-  //  display: block;
-  //}
 }

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -28,7 +28,7 @@
 
   background-color: $primaryWhite;
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
-  border-radius: 5px;
+  border-radius: 12px;
 
   ::-webkit-scrollbar {
     width: 0.4rem;

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -54,14 +54,14 @@
   justify-content: space-between;
 
   font-size: 2.2rem;
-  font-weight: 500;
 
-  padding: 2.4rem 1.6rem;
+  padding: 2.4rem 3.2rem;
 
   background-color: $primaryWhite;
 
   h2 {
     font-size: 2.2rem;
+    font-weight: 500;
     line-height: 2.8rem;
 
     margin: 0;
@@ -69,7 +69,9 @@
 }
 
 .modalContentText {
-  padding: 1.6rem 4rem;
+  color: $tertiaryGray;
+
+  padding: 4rem 5.2rem 2.4rem 4rem;
 }
 
 .modalFooter {
@@ -87,10 +89,10 @@
   display: flex;
   gap: 1.6rem;
 
-  button {
-    width: 2.4rem;
-    height: 2.4rem;
-
-    display: block;
-  }
+  //button {
+  //  width: 2.4rem;
+  //  height: 2.4rem;
+  //
+  //  display: block;
+  //}
 }

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -7,25 +7,39 @@ import Button from '~components/Button/Button';
 import Portal from './Modal';
 
 export const ModalStories: Story = () => {
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div>
-      <button onClick={() => setOpen(true)}>open portal</button>
+      <button onClick={() => setIsOpen(true)} type={'button'}>
+        open portal
+      </button>
       <Portal
-        isOpen={isOpen}
-        title="Modal Title"
-        onClickOutside={() => setOpen(false)}
         footer={
-          <>
-            <div>Footer example</div>
-            <Button type="button" variant="container">
-              Clica aqui
+          <div
+            style={{
+              display: 'flex',
+              gap: '8px',
+              placeContent: 'flex-end',
+              width: '100%',
+            }}
+          >
+            <Button type="button" variant="outlined">
+              Button 1
             </Button>
-          </>
+            <Button type="button" variant="container">
+              Button 2
+            </Button>
+          </div>
         }
+        isOpen={isOpen}
+        onClickOutside={() => setIsOpen(false)}
+        title="Modal Title"
       >
-        CONTENT
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in r
       </Portal>
     </div>
   );

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -4,6 +4,9 @@ import { createPortal } from 'react-dom';
 import classNames from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
 
+import Button from '~components/Button/Button.tsx';
+import { Icon } from '~components/Icon/Icon.tsx';
+
 import scss from './Modal.module.scss';
 
 import type { TModalProps } from './Modal.types';
@@ -43,7 +46,13 @@ function Modal({
             <div className={scss.modalHeader}>
               <h2>{title}</h2>
               <div className={scss.headerButtons}>
-                <button onClick={onClickOutside} type="button" />
+                <Button
+                  circle
+                  icon={<Icon icon={'close'} size={14} />}
+                  onClick={onClickOutside}
+                  type={'button'}
+                  variant={'text'}
+                />
               </div>
             </div>
             <div>


### PR DESCRIPTION
Closes #428 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Ajuste do modal para segundo o figma, e alguns ajustes de componentes internos como icon.

</details>

<details> 
  <summary>
    <b>Changelog</b>
  </summary>
N/A
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>

Antes:
![image](https://github.com/devhatt/octopost/assets/90076846/1cc3b853-4c37-4b17-94e2-57aeeef70148)

<br/>

Depois:
![image](https://github.com/devhatt/octopost/assets/90076846/c5f31e70-74f3-493d-87b6-f8f03a1a745c)


  </summary>

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
