### PR TITLE
Issue 369 - checkbox possa ser descontrolado e controlado

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -8,10 +8,19 @@ export default {
   title: 'Checkbox',
 } satisfies StoryDefault;
 
-export const StoryCheckbox: Story<CheckboxProps> = (props) => (
+export const UncontrolledCheckbox: Story<CheckboxProps> = (props) => (
   <Checkbox {...props} />
 );
+export const ControlledCheckbox: Story<CheckboxProps> = (props) => {
+  const test = false;
 
-StoryCheckbox.args = {
+  return <Checkbox {...props} checked={test} />;
+};
+
+UncontrolledCheckbox.args = {
+  children: 'Hello',
+};
+
+ControlledCheckbox.args = {
   children: 'Hello',
 };

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, forwardRef } from 'react';
+import { ChangeEvent, forwardRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -8,15 +8,18 @@ import { CheckboxProps } from './Checkbox.types';
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ({ children, ...props }, ref) => {
+    const [isChecked, setIsChecked] = useState<boolean>(false);
     const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
       if (props.onChange) props.onChange(event.target.checked);
+      setIsChecked(event.target.checked);
     };
+    const value = props.checked ?? isChecked;
 
     return (
       <label className={classNames(scss.container, props.className)}>
         <input
           {...props}
-          checked={props.checked}
+          checked={value}
           className={scss.input}
           onChange={handleChange}
           ref={ref}


### PR DESCRIPTION
Closes #369 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Tornando o componente que era apenas controlado para ser também descontrolado caso o componente pai não use a props `checked`.

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

[checkbox.webm](https://github.com/devhatt/octopost/assets/90076846/d17fe54f-1bcb-4f81-a6ee-022c2a049b06)


</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [ ] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
