### PR TITLE
refactor the test for the use of getAllByText

### DIFF
--- a/src/components/CharacterLimitMainText/CharacterLimitMainText.spec.tsx
+++ b/src/components/CharacterLimitMainText/CharacterLimitMainText.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable testing-library/no-node-access -- esses comentários devem ser resolvidos quando o TODO desse arquivo for resolvido */
 /* eslint-disable testing-library/no-container -- esses comentários devem ser resolvidos quando o TODO desse arquivo for resolvido */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import CharacterLimitMainText from './CharacterLimitMainText';
 
@@ -13,9 +13,9 @@ describe('CharacterLimitMainText map test', () => {
       { id: '3', maxLength: 20, svg: <svg />, value: 'Option 3' },
     ];
 
-    const { container } = render(<CharacterLimitMainText module={modules} />);
+    render(<CharacterLimitMainText module={modules} />);
 
-    const optionElements = container.querySelectorAll('.characterLimit');
+    const optionElements = screen.getAllByRole('alert');
     expect(optionElements).toHaveLength(modules.length);
   });
 });

--- a/src/components/CharacterLimitMainText/CharacterLimitMainText.spec.tsx
+++ b/src/components/CharacterLimitMainText/CharacterLimitMainText.spec.tsx
@@ -12,7 +12,7 @@ describe('CharacterLimitMainText map test', () => {
 
     render(<CharacterLimitMainText module={modules} />);
 
-    const optionElements = screen.getAllByRole('alert');
+    const optionElements = screen.getAllByText(/\d+/);
     expect(optionElements).toHaveLength(modules.length);
   });
 });

--- a/src/components/CharacterLimitMainText/CharacterLimitMainText.spec.tsx
+++ b/src/components/CharacterLimitMainText/CharacterLimitMainText.spec.tsx
@@ -1,10 +1,7 @@
-/* eslint-disable testing-library/no-node-access -- esses comentários devem ser resolvidos quando o TODO desse arquivo for resolvido */
-/* eslint-disable testing-library/no-container -- esses comentários devem ser resolvidos quando o TODO desse arquivo for resolvido */
 import { render, screen } from '@testing-library/react';
 
 import CharacterLimitMainText from './CharacterLimitMainText';
 
-// TODO: reescrever esses testes usando getByText e getByRole, não usar os selectors de classes que tao sendo usado
 describe('CharacterLimitMainText map test', () => {
   it('renders the correct number of elements', () => {
     const modules = [

--- a/src/components/CharacterLimitMainText/components/CharacterLimit.tsx
+++ b/src/components/CharacterLimitMainText/components/CharacterLimit.tsx
@@ -24,7 +24,7 @@ function CharacterLimit(props: IModuleProps): ReactNode {
   });
 
   return (
-    <div className={svgColor}>
+    <div className={svgColor} role="alert">
       {props.svg}
       <div className={characterLimitClass}>
         <span>{remainingCharacters}</span>

--- a/src/components/CharacterLimitMainText/components/CharacterLimit.tsx
+++ b/src/components/CharacterLimitMainText/components/CharacterLimit.tsx
@@ -24,7 +24,7 @@ function CharacterLimit(props: IModuleProps): ReactNode {
   });
 
   return (
-    <div className={svgColor} role="alert">
+    <div className={svgColor}>
       {props.svg}
       <div className={characterLimitClass}>
         <span>{remainingCharacters}</span>


### PR DESCRIPTION
Closes #506  


<details open> 
  <summary>
    <b>Feature</b>
  </summary>


Essa task tinha como objetivo em alterar o test que antes era com `className` e agora o test passou a ser com `getAllByText`. Nesse PR fiz somente a alteração do test. 

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>


![image](https://github.com/devhatt/octopost/assets/82889172/69854d6c-d538-4fe7-82d1-aea35887709e)


<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [X] Build working correctly
- [X] Tests created
</details>

</details>