### PR TITLE
Character limit no MainComposer do Tabber

### DIFF
--- a/src/components/CharacterLimitMainText/CharacterLimit.module.scss
+++ b/src/components/CharacterLimitMainText/CharacterLimit.module.scss
@@ -25,6 +25,6 @@
   gap: 0.5rem;
 
   &.exceeded svg path {
-    fill: global.$primaryGray;
+    fill: global.$secondaryRed;
   }
 }

--- a/src/components/MainComposer/components/ComposerEditor/ComposerEditor.tsx
+++ b/src/components/MainComposer/components/ComposerEditor/ComposerEditor.tsx
@@ -117,16 +117,6 @@ function ComposerEditor(props: ComposerEditorProps): ReactNode {
           svg={null}
           value={props.value ?? inputValue}
         />
-        <div className={scss.characterLimitWrapper}>
-          {socialLimits.socialLimits.map((postMode) => (
-            <CharacterLimit
-              key={postMode.socialMediaId}
-              maxLength={postMode.limit}
-              svg={socialMedias.get(postMode.socialMediaId)?.icon}
-              value={props.value ?? inputValue}
-            />
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/src/components/MainComposer/components/ComposerEditor/ComposerEditor.tsx
+++ b/src/components/MainComposer/components/ComposerEditor/ComposerEditor.tsx
@@ -113,9 +113,9 @@ function ComposerEditor(props: ComposerEditorProps): ReactNode {
       />
       <div className={scss.charactersLimitContainer}>
         <CharacterLimit
-          maxLength={socialLimits.maxLimit}
+          maxLength={props.currentMaxLimit ?? socialLimits.maxLimit}
           svg={null}
-          value={inputValue}
+          value={props.value ?? inputValue}
         />
         <div className={scss.characterLimitWrapper}>
           {socialLimits.socialLimits.map((postMode) => (
@@ -123,7 +123,7 @@ function ComposerEditor(props: ComposerEditorProps): ReactNode {
               key={postMode.socialMediaId}
               maxLength={postMode.limit}
               svg={socialMedias.get(postMode.socialMediaId)?.icon}
-              value={inputValue}
+              value={props.value ?? inputValue}
             />
           ))}
         </div>

--- a/src/components/MainComposer/components/ComposerEditor/ComposerEditor.tsx
+++ b/src/components/MainComposer/components/ComposerEditor/ComposerEditor.tsx
@@ -117,6 +117,18 @@ function ComposerEditor(props: ComposerEditorProps): ReactNode {
           svg={null}
           value={props.value ?? inputValue}
         />
+        {!props.postMode && (
+          <div className={scss.characterLimitWrapper}>
+            {socialLimits.socialLimits.map((postMode) => (
+              <CharacterLimit
+                key={postMode.socialMediaId}
+                maxLength={postMode.limit}
+                svg={socialMedias.get(postMode.socialMediaId)?.icon}
+                value={props.value ?? inputValue}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/MainComposer/components/ComposerEditor/ComposerEditor.types.ts
+++ b/src/components/MainComposer/components/ComposerEditor/ComposerEditor.types.ts
@@ -9,6 +9,7 @@ export type TInputPostChange = (
 
 export type ComposerEditorProps = PropsWithChildren<{
   accountId?: string;
+  currentMaxLimit?: number;
   onChange?: TInputChange;
   onChangePost?: TInputPostChange;
   onError?: (error: ErrorMapText) => void;

--- a/src/components/MainComposer/components/MainComposerBase/MainComposerBase.tsx
+++ b/src/components/MainComposer/components/MainComposerBase/MainComposerBase.tsx
@@ -22,6 +22,7 @@ function MainComposerBase(props: MainComposerBaseProps): ReactNode {
     <div className={scss.container}>
       <ComposerEditor
         accountId={props.accountId}
+        currentMaxLimit={props.currentMaxLimit ?? undefined}
         onChangePost={props.onChange}
         onError={handleTextErrors}
         postMode={props.postMode}

--- a/src/components/MainComposer/components/MainComposerBase/MainComposerBase.type.ts
+++ b/src/components/MainComposer/components/MainComposerBase/MainComposerBase.type.ts
@@ -7,6 +7,7 @@ import { ErrorMediaInput } from '../InputMediaGroup/InputMediaGroup.type';
 
 export type MainComposerBaseProps = {
   accountId?: string;
+  currentMaxLimit?: number;
   onChange?: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   onErrorMedia?: (error: ErrorMediaInput) => void;
   onErrorText?: (error: ErrorMapText) => void;

--- a/src/components/Tabber/Tabber.tsx
+++ b/src/components/Tabber/Tabber.tsx
@@ -22,11 +22,11 @@ const makeId = (account: AccountPost): `${string}-${string}` =>
 function getCurrentPostModeMaxLimit(
   currentValidator: PostMode['validators'] | undefined
 ): number | null {
-  if (!currentValidator) return null;
-  if ('text' in currentValidator) {
-    return currentValidator.text.maxLength;
+  let limit = null;
+  if (currentValidator && 'text' in currentValidator) {
+    limit = currentValidator.text.maxLength;
   }
-  return null;
+  return limit;
 }
 
 function Tabber(): ReactNode {

--- a/src/components/Tabber/Tabber.tsx
+++ b/src/components/Tabber/Tabber.tsx
@@ -19,6 +19,16 @@ import { Tab, TabId, Tabs as TabsType } from './Tabber.types';
 const makeId = (account: AccountPost): `${string}-${string}` =>
   `${account.id}-${account.socialMediaId}`;
 
+function getCurrentPostModeMaxLimit(
+  currentValidator: PostMode['validators'] | undefined
+): number | null {
+  if (!currentValidator) return null;
+  if ('text' in currentValidator) {
+    return currentValidator.text.maxLength;
+  }
+  return null;
+}
+
 function Tabber(): ReactNode {
   const { accounts } = useAccountStore();
   const { socialMedias } = useSocialMediaStore();
@@ -70,6 +80,10 @@ function Tabber(): ReactNode {
   };
 
   const currentPostMode = getCurrentPostMode();
+
+  const currentPostModeMaxLimit = getCurrentPostModeMaxLimit(
+    currentPostMode?.validators
+  );
 
   const handleContentChange = (e: ChangeEvent<HTMLTextAreaElement>): void => {
     if (!currentTab || !tabs[currentTab]) return;
@@ -124,6 +138,7 @@ function Tabber(): ReactNode {
           />
           <MainComposerBase
             accountId={tabs[currentTab].account.id.toString()}
+            currentMaxLimit={currentPostModeMaxLimit ?? undefined}
             onChange={handleContentChange}
             postMode={currentPostMode ?? undefined}
             value={


### PR DESCRIPTION
Closes #557 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Character limit exibindo o limite de cada postmode de cada rede social separadamente ao invés do total como é feito no MainComposer.

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>

[CharacterLimit.webm](https://github.com/devhatt/octopost/assets/90076846/eae188c3-b90d-4aa3-aad5-1b9ce84d5eee)

  </summary>

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
