### PR TITLE
chore: add correct icon & adjust name

### DIFF
--- a/src/components/FeedbackError/FeedbackError.tsx
+++ b/src/components/FeedbackError/FeedbackError.tsx
@@ -54,7 +54,7 @@ function FeedbackError(): ReactNode {
             <Icon
               className={scss.dropDownIcon}
               data-testid="dropdown-arrow"
-              icon="TriangleDropArrow"
+              icon="triangle-drop-arrow"
               size={10}
             />
           </button>

--- a/src/components/FeedbackError/FeedbackError.tsx
+++ b/src/components/FeedbackError/FeedbackError.tsx
@@ -54,7 +54,7 @@ function FeedbackError(): ReactNode {
             <Icon
               className={scss.dropDownIcon}
               data-testid="dropdown-arrow"
-              icon="dropDownArrow"
+              icon="TriangleDropArrow"
               size={10}
             />
           </button>

--- a/src/components/Icon/data.ts
+++ b/src/components/Icon/data.ts
@@ -16,7 +16,7 @@ import TriangleLeftArrow from './icons/TriangleLeftArrow.svg?react';
 
 export const icons = {
   alert: Alert,
-  arrowRight: ArrowRight,
+  'arrow-right': ArrowRight,
   check: Check,
   close: Close,
   hamburguer: Hamburguer,
@@ -28,6 +28,6 @@ export const icons = {
   'small-circle-filled': SmallCircleFilled,
   star: Star,
   'star-filled': StarFilled,
-  TriangleDropArrow: TriangleDropArrow,
-  TriangleLeftArrow: TriangleLeftArrow,
+  'triangle-drop-arrow': TriangleDropArrow,
+  'triangle-left-arrow': TriangleLeftArrow,
 };

--- a/src/components/Icon/data.ts
+++ b/src/components/Icon/data.ts
@@ -2,7 +2,7 @@ import Alert from './icons/alert.svg?react';
 import ArrowRight from './icons/arrow-right.svg?react';
 import Check from './icons/check.svg?react';
 import Close from './icons/close.svg?react';
-import DropDownArrow from './icons/drop-down.svg?react';
+import TriangleDropArrow from './icons/drop-down.svg?react';
 import Hamburguer from './icons/hamburguer.svg?react';
 import LeftArrow from './icons/left-arrow.svg?react';
 import Mag from './icons/mag.svg?react';
@@ -12,13 +12,13 @@ import RightArrow from './icons/right-arrow.svg?react';
 import SmallCircleFilled from './icons/small-circle-filled.svg?react';
 import StarFilled from './icons/star-filled.svg?react';
 import Star from './icons/star.svg?react';
+import TriangleLeftArrow from './icons/TriangleLeftArrow.svg?react';
 
 export const icons = {
   alert: Alert,
   arrowRight: ArrowRight,
   check: Check,
   close: Close,
-  dropDownArrow: DropDownArrow,
   hamburguer: Hamburguer,
   'left-arrow': LeftArrow,
   mag: Mag,
@@ -28,4 +28,6 @@ export const icons = {
   'small-circle-filled': SmallCircleFilled,
   star: Star,
   'star-filled': StarFilled,
+  TriangleDropArrow: TriangleDropArrow,
+  TriangleLeftArrow: TriangleLeftArrow,
 };

--- a/src/components/Icon/icons/TriangleLeftArrow.svg
+++ b/src/components/Icon/icons/TriangleLeftArrow.svg
@@ -1,0 +1,3 @@
+<svg width="5" height="10" viewBox="0 0 5 10" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 0L0 5L5 10V0Z" fill="currentColor"/>
+</svg>

--- a/src/pages/home/components/ActionBar/ActionBar.tsx
+++ b/src/pages/home/components/ActionBar/ActionBar.tsx
@@ -13,7 +13,7 @@ function ActionBar(): ReactNode {
         <p className={scss.composeLabel}>Compose</p>
       </div>
       <button className={scss.navigationIconContainer}>
-        <Icon className={scss.arrowIcon} icon="arrowRight" size={12} />
+        <Icon className={scss.arrowIcon} icon="arrow-right" size={12} />
       </button>
 
       <Button className={scss.submit} variant="container">

--- a/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.tsx
+++ b/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.tsx
@@ -76,7 +76,8 @@ function SocialAccordion(props: SocialAccordionProps): ReactNode {
                 aria-label={
                   isOpen ? 'Accordion is open' : 'Accordion is closed'
                 }
-                icon={isOpen ? 'dropDownArrow' : 'left-arrow'}
+                className={isOpen ? scss.rotateIconUp : scss.rotateIconDown}
+                icon={isOpen ? 'TriangleDropArrow' : 'TriangleLeftArrow'}
                 size={16}
               />
             </div>

--- a/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.tsx
+++ b/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.tsx
@@ -77,7 +77,7 @@ function SocialAccordion(props: SocialAccordionProps): ReactNode {
                   isOpen ? 'Accordion is open' : 'Accordion is closed'
                 }
                 className={isOpen ? scss.rotateIconUp : scss.rotateIconDown}
-                icon={isOpen ? 'TriangleDropArrow' : 'TriangleLeftArrow'}
+                icon={isOpen ? 'triangle-drop-arrow' : 'triangle-left-arrow'}
                 size={16}
               />
             </div>


### PR DESCRIPTION
Closes #548 


  <summary>
    <b>Feature</b>
  </summary>

A tarefa consiste em ajustar a seta do socialAccordion para manter a consistência do layout, pois, antes, tínhamos dois tipos de setas diferentes, conforme retrata a imagem abaixo.

Eu também fiz uma mudança no nome da "seta" para baixo. No projeto, temos ícones que são, de fato, setas, e temos triângulos que lembram setas, porém são triângulos e, em algum momento, poderia acabar havendo uma confusão do ponto de vista semântico. Portanto, em vez de chamar dropDownArrow, agora chama-se TriangleDropArrow (dando a entender que é uma seta para baixo, mas em formato de triângulo).


  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

Layout:

Como esta:
![image](https://github.com/devhatt/octopost/assets/30197026/284c1ea6-746b-4c44-a971-f4a91a85a625)
![image](https://github.com/devhatt/octopost/assets/30197026/ef803fbe-8ba4-4ef1-b12c-6f958727519b)


Como estava:
![image](https://github.com/devhatt/octopost/assets/30197026/e6b07b70-f9fa-43cf-86a4-cbc4bc7ba2be)





<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [X] Issue linked
- [X] Build working correctly
</details>


