### PR TITLE
fix: socialaccordion test

### DIFF
--- a/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
+++ b/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Mock } from 'vitest';
 
 import {
   mockedAccounts,
@@ -8,6 +9,19 @@ import {
 
 import SocialAccordion from './SocialAccordion';
 
+const mockAddAccount = vi.fn();
+const mockRemoveAccount = vi.fn();
+
+vi.mock('~stores/useAccountStore', () => ({
+  useAccountStore: (): {
+    addAccount: Mock;
+    removeAccount: Mock;
+  } => ({
+    addAccount: mockAddAccount,
+    removeAccount: mockRemoveAccount,
+  }),
+}));
+
 vi.mock(
   '~stores/useSocialMediaStore/useSocialMediaStore',
   () => mockedUseSocialMediaStore
@@ -15,51 +29,92 @@ vi.mock(
 
 vi.spyOn(window, 'scrollTo');
 
-// TODO: revisitar esse teste pois está falhando
-describe.skip('SocialAccordion', () => {
-  describe('when initilize', () => {
-    it('renders the component', () => {
+const mockDiscordData = mockedAccounts().data.DISCORD_EXAMPLE_ID;
+
+describe('SocialAccordion', () => {
+  it('renders the component', () => {
+    render(
+      <SocialAccordion
+        accounts={mockedAccounts().data.DISCORD_EXAMPLE_ID}
+        error={false}
+        socialMediaId="DISCORD_EXAMPLE_ID"
+      />
+    );
+    const accordion = screen.getByText(/discord/i);
+
+    expect(accordion).toBeInTheDocument();
+  });
+
+  it('renders the intern content of accordion when is open', async () => {
+    render(
+      <SocialAccordion
+        accounts={mockDiscordData}
+        error={false}
+        socialMediaId="DISCORD_EXAMPLE_ID"
+      />
+    );
+
+    const accordion = screen.getByText(/discord/i);
+    await userEvent.click(accordion);
+
+    const innerContent = screen.getByText(mockDiscordData[0].userName);
+
+    expect(innerContent).toBeInTheDocument();
+  });
+
+  it('shows the error on screen if error={true}', () => {
+    render(
+      <SocialAccordion accounts={[]} error socialMediaId="DISCORD_EXAMPLE_ID" />
+    );
+    const error = screen.getByText(/error/i);
+
+    expect(error).toBeInTheDocument();
+  });
+
+  describe('social tab switch', () => {
+    it('activates social tab when switch is enable', async () => {
       render(
         <SocialAccordion
-          accounts={mockedAccounts().data.DISCORD_EXAMPLE_ID}
+          accounts={mockDiscordData}
           error={false}
           socialMediaId="DISCORD_EXAMPLE_ID"
         />
       );
+
       const accordion = screen.getByText(/discord/i);
+      await userEvent.click(accordion);
 
-      expect(accordion).toBeInTheDocument();
+      const switchesComponent = screen.getAllByRole('checkbox');
+      await userEvent.click(switchesComponent[0]);
+
+      expect(mockAddAccount).toHaveBeenCalledWith(mockDiscordData[0]);
     });
-
-    it('renders the intern content of accordion when is open', () => {
+    it('deactivates social tab when switch is enable', async () => {
       render(
         <SocialAccordion
-          accounts={mockedAccounts().data.DISCORD_EXAMPLE_ID}
+          accounts={mockDiscordData}
           error={false}
           socialMediaId="DISCORD_EXAMPLE_ID"
         />
       );
-      const innerContent = screen.getByText(/discord/i);
 
-      expect(innerContent).toBeInTheDocument();
-    });
+      const accordion = screen.getByText(/discord/i);
+      await userEvent.click(accordion);
 
-    it('shows the error on screen if error={true}', () => {
-      render(
-        <SocialAccordion
-          accounts={[]}
-          error
-          socialMediaId="DISCORD_EXAMPLE_ID"
-        />
-      );
-      const error = screen.getByText(/error/i);
+      const switchesComponent = screen.getAllByRole('checkbox');
+      const [firstAccountSwitch] = switchesComponent;
 
-      expect(error).toBeInTheDocument();
+      await userEvent.click(firstAccountSwitch);
+      await userEvent.click(firstAccountSwitch);
+
+      const [firstAccount] = mockDiscordData;
+
+      expect(mockRemoveAccount).toHaveBeenLastCalledWith(firstAccount.id);
     });
   });
 
-  describe('when click', () => {
-    it('closes the accordion', () => {
+  describe('when click 2 times', () => {
+    it('closes the accordion', async () => {
       render(
         <SocialAccordion
           accounts={mockedAccounts().data.DISCORD_EXAMPLE_ID}
@@ -67,23 +122,18 @@ describe.skip('SocialAccordion', () => {
           socialMediaId="DISCORD_EXAMPLE_ID"
         />
       );
-      const accounts = mockedAccounts().data;
 
-      Object.values(accounts.DISCORD_EXAMPLE_ID).forEach(async (account) => {
-        const accordion = await screen.findByRole('button');
-        await userEvent.click(accordion);
+      const accordion = screen.getByText(/discord/i);
+      await userEvent.click(accordion);
 
-        const userCard = screen.getByText(new RegExp(account.userName, 'i'));
+      const innerContent = screen.getByText(mockDiscordData[0].userName);
 
-        expect(userCard).toBeInTheDocument();
+      expect(innerContent).toBeInTheDocument();
 
-        await userEvent.click(accordion);
+      await userEvent.click(accordion);
 
-        await waitFor(() =>
-          expect(
-            screen.queryByText(new RegExp(account.userName, 'i'))
-          ).not.toBeInTheDocument()
-        );
+      await waitFor(() => {
+        expect(innerContent).not.toBeInTheDocument();
       });
     });
   });
@@ -102,24 +152,20 @@ describe.skip('SocialAccordion', () => {
       expect(accountQuantity).toBeInTheDocument();
     });
 
-    it('renders with one if list have one account', () => {
-      const accounts = mockedAccounts().data;
+    it('renders with one account if list have one account', () => {
+      const [account] = mockedAccounts().data.DISCORD_EXAMPLE_ID;
 
       render(
         <SocialAccordion
-          accounts={accounts.DISCORD_EXAMPLE_ID}
+          accounts={[account]}
           error={false}
           socialMediaId="DISCORD_EXAMPLE_ID"
         />
       );
 
-      Object.values(accounts.DISCORD_EXAMPLE_ID).forEach((account) => {
-        const accountQuantity = screen.getByText(
-          new RegExp(String(account.id), 'i')
-        );
+      const accountQuantity = screen.getByText(/1/);
 
-        expect(accountQuantity).toBeInTheDocument();
-      });
+      expect(accountQuantity).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
+++ b/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
@@ -84,8 +84,8 @@ describe('SocialAccordion', () => {
       const accordion = screen.getByText(/discord/i);
       await userEvent.click(accordion);
 
-      const switchesComponent = screen.getAllByRole('checkbox');
-      await userEvent.click(switchesComponent[0]);
+      const [firstAccountSwitch] = screen.getAllByRole('checkbox');
+      await userEvent.click(firstAccountSwitch);
 
       expect(mockAddAccount).toHaveBeenCalledWith(mockDiscordData[0]);
     });
@@ -101,8 +101,7 @@ describe('SocialAccordion', () => {
       const accordion = screen.getByText(/discord/i);
       await userEvent.click(accordion);
 
-      const switchesComponent = screen.getAllByRole('checkbox');
-      const [firstAccountSwitch] = switchesComponent;
+      const [firstAccountSwitch] = screen.getAllByRole('checkbox');
 
       await userEvent.click(firstAccountSwitch);
       await userEvent.click(firstAccountSwitch);

--- a/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
+++ b/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
@@ -35,7 +35,7 @@ describe('SocialAccordion', () => {
   it('renders the component', () => {
     render(
       <SocialAccordion
-        accounts={mockedAccounts().data.DISCORD_EXAMPLE_ID}
+        accounts={mockDiscordData}
         error={false}
         socialMediaId="DISCORD_EXAMPLE_ID"
       />
@@ -153,7 +153,7 @@ describe('SocialAccordion', () => {
     });
 
     it('renders with one account if list have one account', () => {
-      const [account] = mockedAccounts().data.DISCORD_EXAMPLE_ID;
+      const [account] = mockDiscordData;
 
       render(
         <SocialAccordion

--- a/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
+++ b/src/pages/home/components/Sidebar/components/SocialAccordion/SocialAccordion.spec.tsx
@@ -72,7 +72,7 @@ describe('SocialAccordion', () => {
   });
 
   describe('social tab switch', () => {
-    it('activates social tab when switch is enable', async () => {
+    it('activates social tab when is enable', async () => {
       render(
         <SocialAccordion
           accounts={mockDiscordData}
@@ -89,7 +89,7 @@ describe('SocialAccordion', () => {
 
       expect(mockAddAccount).toHaveBeenCalledWith(mockDiscordData[0]);
     });
-    it('deactivates social tab when switch is enable', async () => {
+    it('deactivates social tab when is disable', async () => {
       render(
         <SocialAccordion
           accounts={mockDiscordData}


### PR DESCRIPTION
Closes #509 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Correção dos testes do SocialAccordion

</details>


<details open> 
  <summary>
    <b>Visual evidences :framed_picture: </b>

![image](https://github.com/user-attachments/assets/57ca8c47-f8de-4970-a578-a6da82473c5d)
![image](https://github.com/user-attachments/assets/fa335188-f7f3-42c6-bea1-ac15d7637be2)


  </summary>

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [x] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>

1. Adicionado o mock da store de account para que os métodos addAccount e removeAccount sejam testados.
2. Adicionada variáveis para melhor leitura
3. Simplificado alguns testes
4. Adicionado testes de adicionar e remover conta ativadas no tabber

</details>
