### PR TITLE
refactor: adjust the accordio tab header

### DIFF
--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -19,10 +19,8 @@
   display: none;
 
   color: $primaryWhite;
-  font-size: 4rem;
-  font-weight: 900;
 
-  margin-right: 2rem;
+  margin-top: 0.2rem;
 
   cursor: pointer;
 }
@@ -57,19 +55,18 @@
     font-size: 1.6rem;
     line-height: 1;
 
-    padding: 1.2rem;
+    padding: 1.3rem;
 
     position: relative;
 
     background-color: $secondaryPurple;
     border-radius: 17px 17px 0 0;
 
-    &::before {
-      font-size: 1.8rem;
+    .innerHeader {
+      display: flex;
+      gap: 1.5rem;
 
-      margin-right: 1rem;
-
-      content: '⬤';
+      align-items: center;
     }
   }
 

--- a/src/components/AccordionTab/AccordionTab.module.scss
+++ b/src/components/AccordionTab/AccordionTab.module.scss
@@ -55,7 +55,7 @@
     font-size: 1.6rem;
     line-height: 1;
 
-    padding: 1.3rem;
+    padding: 1.3rem 2.2rem;
 
     position: relative;
 

--- a/src/components/AccordionTab/AccordionTab.tsx
+++ b/src/components/AccordionTab/AccordionTab.tsx
@@ -19,7 +19,7 @@ function AccordionTab({
   };
   const renderCloseButton = (): ReactNode => (
     <button className={scss.closeButton} onClick={handleClose} type="button">
-      <Icon icon="minus" size={16} />
+      <Icon icon={isOpen ? 'minus' : 'plus'} size={16} />
     </button>
   );
 

--- a/src/components/AccordionTab/AccordionTab.tsx
+++ b/src/components/AccordionTab/AccordionTab.tsx
@@ -17,7 +17,6 @@ function AccordionTab({
   const handleClose = (): void => {
     if (props.onChangeOpen) props.onChangeOpen(!isOpen);
   };
-
   const renderCloseButton = (): ReactNode => (
     <button className={scss.closeButton} onClick={handleClose} type="button">
       <Icon icon="minus" size={16} />
@@ -26,7 +25,10 @@ function AccordionTab({
 
   const renderHeader = (): ReactNode => (
     <div className={scss.header}>
-      <p className={scss.headerTitle}>{props.title}</p>
+      <div className={scss.innerHeader}>
+        <Icon icon="circle" size={12} />
+        <p className={scss.headerTitle}>{props.title}</p>
+      </div>
       {hideCloseButton ? null : renderCloseButton()}
     </div>
   );

--- a/src/components/Icon/data.ts
+++ b/src/components/Icon/data.ts
@@ -1,6 +1,7 @@
 import Alert from './icons/alert.svg?react';
 import ArrowRight from './icons/arrow-right.svg?react';
 import Check from './icons/check.svg?react';
+import Circle from './icons/circle.svg?react';
 import Close from './icons/close.svg?react';
 import TriangleDropArrow from './icons/drop-down.svg?react';
 import Hamburguer from './icons/hamburguer.svg?react';
@@ -18,6 +19,7 @@ export const icons = {
   alert: Alert,
   'arrow-right': ArrowRight,
   check: Check,
+  circle: Circle,
   close: Close,
   hamburguer: Hamburguer,
   'left-arrow': LeftArrow,

--- a/src/components/Icon/icons/circle.svg
+++ b/src/components/Icon/icons/circle.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 12C9.31371 12 12 9.31371 12 6C12 2.68629 9.31371 0 6 0C2.68629 0 0 2.68629 0 6C0 9.31371 2.68629 12 6 12Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Closes #547 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Pequenos ajustes no componente AccordionTab para manter a consistência do layout, seguindo o Figma.</details>



<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

Descricao da issue:
![image](https://github.com/user-attachments/assets/6f6e09b5-5145-42b3-91ef-48e28ac3dcc8)


Como Ficou:
![image](https://github.com/user-attachments/assets/3ce2118f-76bc-48c0-8b4e-824ef6f19ea1)

![iconChange](https://github.com/user-attachments/assets/19c97000-3c89-4902-a599-55f8df72d9e2)


Como estava:
![image](https://github.com/user-attachments/assets/ce868b11-9101-4287-800d-80b9cb49ac08)




</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [ ] Issue linked
- [ ] Build working correctly
- [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>

</details>
