### PR TITLE
refactor: ajust input media aesthetics details

### DIFF
--- a/src/components/MainComposer/components/InputMediaGroup/InputMediaGroup.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/InputMediaGroup.module.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
   gap: 1.4rem;
 
   align-items: center;

--- a/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
@@ -19,7 +19,7 @@
 }
 
 .button {
-  height: 116px;
+  height: 11.6rem;
 
   border: 2px dotted global.$baseColor;
 }

--- a/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
@@ -19,11 +19,14 @@
 }
 
 .button {
+  height: 116px;
+
   border: 2px dotted global.$baseColor;
 }
 
 .buttonSelected {
   width: 100%;
+  height: 100%;
 
   border: 2px solid global.$tertiaryPurple;
 }

--- a/src/components/MainComposer/components/MainComposerBase/MainComposerBase.module.scss
+++ b/src/components/MainComposer/components/MainComposerBase/MainComposerBase.module.scss
@@ -7,6 +7,8 @@
   flex-grow: 1;
 
   .bottomWrapper {
+    height: 100%;
+
     padding: 1.6rem;
     padding-top: 0;
 

--- a/src/pages/home/components/Sidebar/components/SocialMediaForm/SocialMediaForm.module.scss
+++ b/src/pages/home/components/Sidebar/components/SocialMediaForm/SocialMediaForm.module.scss
@@ -2,6 +2,8 @@
 @use '~styles/breakpoints.scss' as breakpoints;
 
 .selectionGrid {
+  height: 10.4rem;
+
   display: grid;
   flex-wrap: wrap;
   grid-template-columns: repeat(auto-fit, minmax(16.5rem, 1fr));


### PR DESCRIPTION
Closes #542 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>
Foram ajustados componentes que estavam influenciando na estética do input de mídia.

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

Como estava:
https://github.com/user-attachments/assets/08ba74ee-e646-4fa6-9792-cb0da0cfd8a0


Como ficou/esta:
https://github.com/user-attachments/assets/a8f70808-d968-464e-8c0b-26b11a944f9e






</details>


<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
