### PR TITLE
refactor: adjust input media aesthetics details

### DIFF
--- a/src/components/MainComposer/components/InputMediaGroup/InputMediaGroup.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/InputMediaGroup.module.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
   gap: 1.4rem;
 
   align-items: start;

--- a/src/components/MainComposer/components/InputMediaGroup/InputMediaGroup.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/InputMediaGroup.module.scss
@@ -7,7 +7,7 @@
   grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
   gap: 1.4rem;
 
-  align-items: center;
+  align-items: start;
   justify-content: start;
 
   .imageGroup {
@@ -31,6 +31,7 @@
 
     .removeButton {
       width: 2.2rem;
+      height: 2.2rem;
 
       color: global.$tertiaryPurple;
       text-align: center;

--- a/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
@@ -2,12 +2,17 @@
 
 .button,
 .buttonSelected {
+  height: 100%;
   overflow: hidden;
 
   display: flex;
 
   align-items: center;
   justify-content: center;
+
+  padding: 5.2rem;
+
+  position: relative;
 
   transition: color 0.3s ease;
 
@@ -34,6 +39,10 @@
 
 .imagePlaceholder,
 .imageSelected {
+  max-width: 100%;
+  max-height: 100%;
+
+  position: absolute;
   object-fit: cover;
 }
 

--- a/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
+++ b/src/components/MainComposer/components/InputMediaGroup/components/InputMedia/InputMedia.module.scss
@@ -19,7 +19,7 @@
   cursor: pointer;
 
   &:hover {
-    background-color: global.$hovering;
+    background-color: global.$pressing;
   }
 }
 


### PR DESCRIPTION
Closes #542 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Antes de tudo, é importante destacar que, segundo o Ale, não há necessidade de seguir à risca a consistência do layout, pois, futuramente, esse componente passará por alterações. Foram realizadas modificações para que o campo de entrada de mídia tenha um tamanho padrão e consistente. Além disso, o "X", que é responsável por remover uma mídia já adicionada, foi ajustado, já que anteriormente ele apresentava um formato oval em vez de circular.

</details>


<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

Estava:
https://github.com/user-attachments/assets/82cfce4b-455e-43b2-a774-9e371898297f




Ficou/esta:
https://github.com/user-attachments/assets/fd200a32-6aa1-47e5-bed2-e2ff53bd239c



</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [ ] Issue linked
- [ ] Build working correctly
- [ ] Tests created
</details>

