### PR TITLE
refactor: readjust tabber responsive

### DIFF
--- a/src/components/MainComposer/components/ComposerEditor/ComposerEditor.module.scss
+++ b/src/components/MainComposer/components/ComposerEditor/ComposerEditor.module.scss
@@ -24,6 +24,7 @@ textarea {
 
 .charactersLimitContainer {
   display: flex;
+  flex-wrap: wrap;
 
   justify-content: space-between;
 
@@ -32,6 +33,7 @@ textarea {
 
 .characterLimitWrapper {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.8rem;
 
   align-items: center;

--- a/src/components/Preview/Preview.module.scss
+++ b/src/components/Preview/Preview.module.scss
@@ -2,7 +2,6 @@
 @use '~styles/breakpoints.scss' as *;
 
 .container {
-  width: 54.2rem;
   height: 69.7rem;
 
   display: none;

--- a/src/components/Tabber/PostModes/PostModes.module.scss
+++ b/src/components/Tabber/PostModes/PostModes.module.scss
@@ -1,7 +1,11 @@
 @use '~styles/global.scss';
+@use '~styles/breakpoints.scss' as *;
 
 .postModesHeader {
   width: fit-content;
+
+  display: flex;
+  flex-wrap: wrap;
 
   align-self: flex-end;
 }
@@ -11,11 +15,17 @@
   font-size: 1.4rem;
   font-weight: 500;
 
-  padding: 1.2rem;
+  padding: 0.8rem;
 
   cursor: pointer;
 
   &.active {
     color: global.$secondaryPurple;
+  }
+}
+
+@include from1240 {
+  .postModeTitle {
+    padding: 1.2rem;
   }
 }


### PR DESCRIPTION
Closes #614 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Minha task consistia, única e exclusivamente, em fazer o reajuste da responsividade do tabber.
Conforme mostra a image abaixo, ele nao se ajustava:
![image](https://github.com/user-attachments/assets/2b44c7c7-6769-4395-85fb-1783389ff074)


</details>


<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

Como estava:
https://github.com/user-attachments/assets/ef2a3469-939c-451a-b6c6-bc0836bfb1ba

Como ficou:
https://github.com/user-attachments/assets/10c81673-5f1b-4b81-92d8-7830e659a6c4



](url)


</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [ ] Issue linked
- [ ] Build working correctly
- [ ] Tests created
</details>

