### PR TITLE
fix: only allow action bar button when at least one account is selected

### DIFF
--- a/src/pages/home/components/ActionBar/ActionBar.module.scss
+++ b/src/pages/home/components/ActionBar/ActionBar.module.scss
@@ -9,7 +9,7 @@
 
   justify-content: space-between;
 
-  padding: 1.1rem;
+  padding: 0.8rem;
   border-bottom: 1px solid $secondaryGray;
 
   .composeContainer {
@@ -18,8 +18,17 @@
 
     align-items: center;
 
+    padding-left: 1.2rem;
+
+    .closeIcon {
+      color: $tertiaryGray;
+    }
+
     .composeLabel {
       font-size: 1.6rem;
+
+      margin: 0;
+      padding: 0;
     }
   }
 
@@ -33,7 +42,7 @@
 
     justify-content: center;
 
-    background: $secondaryPurple;
+    background-color: $secondaryPurple;
 
     border-radius: 50%;
 

--- a/src/pages/home/components/ActionBar/ActionBar.module.scss
+++ b/src/pages/home/components/ActionBar/ActionBar.module.scss
@@ -47,7 +47,9 @@
     border-radius: 50%;
 
     &:disabled {
-      background: #1d1b201f;
+      background-color: rgba($color: $secondaryGray, $alpha: 0.12);
+
+      cursor: not-allowed;
     }
   }
 

--- a/src/pages/home/components/ActionBar/ActionBar.module.scss
+++ b/src/pages/home/components/ActionBar/ActionBar.module.scss
@@ -33,13 +33,17 @@
 
     justify-content: center;
 
-    background-color: $secondaryPurple;
+    background: $secondaryPurple;
 
     border-radius: 50%;
 
-    .arrowIcon {
-      color: $primaryWhite;
+    &:disabled {
+      background: #1d1b201f;
     }
+  }
+
+  .arrowIcon {
+    color: $primaryWhite;
   }
 
   .submit {

--- a/src/pages/home/components/ActionBar/ActionBar.tsx
+++ b/src/pages/home/components/ActionBar/ActionBar.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+import isEmpty from 'lodash.isempty';
+
 import { useAccountStore } from '~stores/useAccountStore/useAccountStore';
 
 import Button from '~components/Button/Button';
@@ -20,7 +22,7 @@ function ActionBar(): ReactNode {
         circle
         className={scss.navigationIconContainer}
         color="secondary"
-        disabled={accounts.length === 0}
+        disabled={isEmpty(accounts.length)}
         icon={<Icon className={scss.arrowIcon} icon="arrow-right" size={12} />}
       />
       <Button className={scss.submit} variant="container">

--- a/src/pages/home/components/ActionBar/ActionBar.tsx
+++ b/src/pages/home/components/ActionBar/ActionBar.tsx
@@ -1,21 +1,28 @@
 import { ReactNode } from 'react';
 
+import { useAccountStore } from '~stores/useAccountStore/useAccountStore';
+
 import Button from '~components/Button/Button';
 import Icon from '~components/Icon/Icon';
 
 import scss from './ActionBar.module.scss';
 
 function ActionBar(): ReactNode {
+  const { accounts } = useAccountStore();
+
   return (
     <div className={scss.container}>
       <div className={scss.composeContainer}>
         <Icon className={scss.closeIcon} icon="close" size={14} />
         <p className={scss.composeLabel}>Compose</p>
       </div>
-      <button className={scss.navigationIconContainer}>
-        <Icon className={scss.arrowIcon} icon="arrow-right" size={12} />
-      </button>
-
+      <Button
+        circle
+        className={scss.navigationIconContainer}
+        color="secondary"
+        disabled={accounts.length === 0}
+        icon={<Icon className={scss.arrowIcon} icon="arrow-right" size={12} />}
+      />
       <Button className={scss.submit} variant="container">
         Postar
       </Button>


### PR DESCRIPTION
Closes #610 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Ajusta o botão da action bar para ficar disabled a não ser que haja alguma conta selecionada

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![image](https://github.com/user-attachments/assets/7f14fcc7-cc13-4a1e-9b54-4c50dea7441d)
![image](https://github.com/user-attachments/assets/0327f950-3911-4b15-b9b4-ce84d978accf)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [x] Tests created
</details>
